### PR TITLE
WIP: GTK4 Port

### DIFF
--- a/data/ui/menu.xml
+++ b/data/ui/menu.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
+  <requires lib="gtk" version="4.0"/>
   <menu id="wordbook-menu">
     <section>
       <attribute name="id">search-section</attribute>
       <item>
-        <attribute name="label" translatable="yes">Paste &amp; Search</attribute>
+        <attribute name="label" translatable="yes">Paste &amp;amp; Search</attribute>
         <attribute name="action">app.paste-search</attribute>
       </item>
       <item>

--- a/data/ui/settings_window.ui
+++ b/data/ui/settings_window.ui
@@ -1,35 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.1 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
-  <requires lib="libhandy" version="1.2"/>
-  <template class="SettingsWindow" parent="HdyPreferencesWindow">
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0"/>
+  <template class="SettingsWindow" parent="AdwPreferencesWindow">
     <property name="can-focus">False</property>
     <property name="modal">True</property>
     <property name="default-width">380</property>
     <property name="default-height">350</property>
     <property name="destroy-with-parent">True</property>
-    <property name="window-position">center-on-parent</property>
     <child>
-      <object class="HdyPreferencesPage">
+      <object class="AdwPreferencesPage">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="icon-name">emblem-system-symbolic</property>
         <property name="title">General</property>
         <child>
-          <object class="HdyPreferencesGroup">
+          <object class="AdwPreferencesGroup">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Custom Definitions</property>
                 <property name="activatable-widget">cdef_switch</property>
                 <child>
                   <object class="GtkSwitch" id="cdef_switch">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                   </object>
@@ -37,7 +33,7 @@
               </object>
             </child>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Live Search</property>
@@ -45,8 +41,6 @@
                 <property name="subtitle" translatable="yes">Show definition as the terms are typed in</property>
                 <child>
                   <object class="GtkSwitch" id="live_search_switch">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                   </object>
@@ -54,7 +48,7 @@
               </object>
             </child>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Double Click Search</property>
@@ -62,8 +56,6 @@
                 <property name="subtitle" translatable="yes">Search any word by double clicking on it</property>
                 <child>
                   <object class="GtkSwitch" id="double_click_switch">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                   </object>
@@ -71,7 +63,7 @@
               </object>
             </child>
             <child>
-              <object class="HdyComboRow" id="pronunciations_accent_row">
+              <object class="AdwComboRow" id="pronunciations_accent_row">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Pronunciations Accent</property>
@@ -82,25 +74,23 @@
       </object>
     </child>
     <child>
-      <object class="HdyPreferencesPage">
+      <object class="AdwPreferencesPage">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="icon-name">preferences-desktop-apps</property>
         <property name="title">UI</property>
         <child>
-          <object class="HdyPreferencesGroup">
+          <object class="AdwPreferencesGroup">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Use dark UI theme</property>
                 <property name="activatable-widget">dark_ui_switch</property>
                 <child>
                   <object class="GtkSwitch" id="dark_ui_switch">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                   </object>
@@ -108,7 +98,7 @@
               </object>
             </child>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Use dark font theme</property>
@@ -116,8 +106,6 @@
                 <property name="subtitle">Use cyan and light green colors</property>
                 <child>
                   <object class="GtkSwitch" id="dark_font_switch">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                   </object>

--- a/data/ui/shortcuts_window.ui
+++ b/data/ui/shortcuts_window.ui
@@ -1,40 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkShortcutsWindow" id="shortcuts">
     <property name="modal">True</property>
     <child>
       <object class="GtkShortcutsSection">
-        <property name="visible">True</property>
         <property name="section-name">shortcuts</property>
         <property name="max-height">10</property>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">True</property>
             <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Preferences</property>
                 <property name="accelerator">&lt;Primary&gt;comma</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Paste and Search</property>
                 <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;V</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Random Word</property>
                 <property name="accelerator">&lt;Primary&gt;R</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Search Selected Text</property>
                 <property name="accelerator">&lt;Primary&gt;S</property>
               </object>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -30,7 +30,6 @@
                     <child>
                       <object class="GtkButton" id="search_button">
                         <property name="receives-default">True</property>
-                        <property name="has-default">True</property>
                         <property name="icon-name">edit-find-symbolic</property>
                         <style>
                           <class name="suggested-action"/>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -1,83 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.22"/>
-  <requires lib="libhandy" version="1.2"/>
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="icon-name">edit-find-symbolic</property>
-  </object>
-  <object class="GtkImage" id="image2">
-    <property name="visible">True</property>
-    <property name="icon-name">edit-clear-symbolic</property>
-  </object>
-  <object class="GtkImage" id="image3">
-    <property name="visible">True</property>
-    <property name="icon-name">audio-volume-high-symbolic</property>
-  </object>
-  <template class="WordbookGtkWindow" parent="HdyApplicationWindow">
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0"/>
+  <template class="WordbookGtkWindow" parent="AdwApplicationWindow">
     <property name="can-focus">False</property>
     <property name="default-width">390</property>
     <property name="default-height">610</property>
     <property name="icon-name">accesories-dictionary</property>
     <child>
       <object class="GtkBox" id="box">
-        <property name="visible">True</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="HdyHeaderBar" id="header_bar">
+          <object class="AdwHeaderBar" id="header_bar">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="show-close-button">True</property>
             <child type="title">
               <object class="GtkBox">
-                <property name="visible">True</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
                     <property name="hexpand">True</property>
                     <property name="spacing">4</property>
                     <child>
-                      <object class="GtkSearchEntry" id="search_entry">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                      <object class="GtkEntry" id="search_entry">
+                        <property name="hexpand">True</property>
                         <property name="activates-default">True</property>
-                        <property name="primary-icon-activatable">False</property>
-                        <property name="primary-icon-sensitive">False</property>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="search_button">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="has-focus">True</property>
-                        <property name="can-default">True</property>
-                        <property name="has-default">True</property>
                         <property name="receives-default">True</property>
-                        <property name="image">image1</property>
-                        <property name="always-show-image">True</property>
+                        <property name="has-default">True</property>
+                        <property name="icon-name">edit-find-symbolic</property>
                         <style>
                           <class name="suggested-action"/>
                         </style>
                       </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkMenuButton" id="wordbook_menu_button">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
                         <property name="direction">none</property>
                       </object>
-                      <packing>
-                        <property name="position">4</property>
-                      </packing>
                     </child>
                   </object>
                 </child>
@@ -87,193 +50,172 @@
         </child>
         <child>
           <object class="GtkStack" id="main_stack">
-            <property name="visible">True</property>
             <property name="transition-type">crossfade</property>
-            <!-- n-columns=1 n-rows=2 -->
             <child>
-              <object class="GtkGrid" id="download_grid">
-                <property name="visible">True</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <child>
-                  <object class="GtkLabel" id="loading_label">
-                    <property name="visible">True</property>
-                    <property name="margin-bottom">4</property>
-                    <property name="label" translatable="yes">Loading...</property>
-                    <style>
-                      <class name="dim-label"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkProgressBar" id="loading_progress">
-                    <property name="visible">True</property>
-                    <property name="text" translatable="yes">Downloading English WordNet</property>
-                    <property name="ellipsize">end</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
+              <object class="GtkStackPage">
                 <property name="name">download_page</property>
                 <property name="title" translatable="yes">Downloading</property>
-              </packing>
+                <property name="child">
+                  <object class="GtkGrid" id="download_grid">
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <child>
+                      <object class="GtkLabel" id="loading_label">
+                        <property name="margin-bottom">4</property>
+                        <property name="label" translatable="yes">Loading...</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">0</property>
+                        </layout>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkProgressBar" id="loading_progress">
+                        <property name="text" translatable="yes">Downloading English WordNet</property>
+                        <property name="ellipsize">end</property>
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">1</property>
+                        </layout>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
             </child>
             <child>
-              <object class="HdyStatusPage" id="before_search_page">
-                <property name="visible">True</property>
-                <property name="icon-name">com.github.fushinari.Wordbook-symbolic</property>
-                <property name="title" translatable="yes">Wordbook</property>
-                <property name="description" translatable="yes">Lookup definitions of any term</property>
-              </object>
-              <packing>
+              <object class="GtkStackPage">
                 <property name="name">welcome_page</property>
                 <property name="title" translatable="yes">Welcome</property>
-                <property name="position">1</property>
-              </packing>
+                <property name="child">
+                  <object class="AdwStatusPage" id="before_search_page">
+                    <property name="visible">True</property>
+                    <property name="icon-name">com.github.fushinari.Wordbook-symbolic</property>
+                    <property name="title" translatable="yes">Wordbook</property>
+                    <property name="description" translatable="yes">Lookup definitions of any term</property>
+                  </object>
+                </property>
+              </object>
             </child>
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <child>
-                      <object class="HdyClamp">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+              <object class="GtkStackPage">
+                <property name="name">content_page</property>
+                <property name="title" translatable="yes">Content</property>
+                <property name="child">
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="child">
+                      <object class="GtkViewport">
                         <child>
-                          <object class="GtkBox">
+                          <object class="AdwClamp">
                             <property name="visible">True</property>
-                            <property name="orientation">vertical</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="margin-start">18</property>
-                                <property name="margin-end">18</property>
-                                <property name="margin-top">12</property>
-                                <property name="margin-bottom">12</property>
-                                <property name="spacing">18</property>
+                                <property name="orientation">vertical</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="orientation">vertical</property>
+                                    <property name="margin-start">18</property>
+                                    <property name="margin-end">18</property>
+                                    <property name="margin-top">12</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="spacing">18</property>
                                     <child>
-                                      <object class="GtkLabel" id="term_view">
-                                        <property name="visible">True</property>
-                                        <property name="label" translatable="yes">&lt;span size=&quot;large&quot; weight=&quot;bold&quot;&gt;Term&lt;/span&gt;</property>
-                                        <property name="use-markup">True</property>
-                                        <property name="single-line-mode">True</property>
-                                        <property name="xalign">0</property>
+                                      <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="term_view">
+                                            <property name="label" translatable="yes">&lt;span size=&quot;large&quot; weight=&quot;bold&quot;&gt;Term&lt;/span&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="pronunciation_view">
+                                            <property name="label" translatable="yes">&lt;i&gt;/Pronunciation/&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="selectable">True</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="GtkLabel" id="pronunciation_view">
-                                        <property name="visible">True</property>
-                                        <property name="label" translatable="yes">&lt;i&gt;/Pronunciation/&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
-                                        <property name="selectable">True</property>
-                                        <property name="single-line-mode">True</property>
-                                        <property name="xalign">0</property>
+                                      <object class="GtkButton" id="speak_button">
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="icon-name">audio-volume-high-symbolic</property>
+                                        <style>
+                                          <class name="circular"/>
+                                        </style>
                                       </object>
-                                      <packing>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
                                 </child>
                                 <child>
-                                  <object class="GtkButton" id="speak_button">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="halign">center</property>
-                                    <property name="valign">center</property>
-                                    <property name="image">image3</property>
-                                    <property name="relief">none</property>
-                                    <property name="always-show-image">True</property>
-                                    <style>
-                                      <class name="circular"/>
-                                    </style>
+                                  <object class="GtkLabel" id="def_view">
+                                    <property name="margin-start">18</property>
+                                    <property name="margin-end">18</property>
+                                    <property name="margin-top">6</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="wrap">True</property>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="yalign">0</property>
+                                    <attributes>
+                                      <attribute name="scale" value="1.1000000000000001"></attribute>
+                                    </attributes>
+                                        <child>
+                                          <object class="GtkGestureClick" id="def_ctrlr"/>
+                                        </child>
                                   </object>
-                                  <packing>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                               </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="def_view">
-                                <property name="visible">True</property>
-                                <property name="margin-start">18</property>
-                                <property name="margin-end">18</property>
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">12</property>
-                                <property name="wrap">True</property>
-                                <property name="selectable">True</property>
-                                <property name="track-visited-links">False</property>
-                                <property name="xalign">0</property>
-                                <property name="yalign">0</property>
-                                <attributes>
-                                  <attribute name="scale" value="1.1000000000000001"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
                       </object>
-                    </child>
+                    </property>
                   </object>
-                </child>
+                </property>
               </object>
-              <packing>
-                <property name="name">content_page</property>
-                <property name="title" translatable="yes">Content</property>
-                <property name="position">2</property>
-              </packing>
             </child>
             <child>
-              <object class="HdyStatusPage" id="search_fail_page">
-                <property name="visible">True</property>
-                <property name="icon-name">edit-find-symbolic</property>
-                <property name="description" translatable="yes">No definition found</property>
-              </object>
-              <packing>
+              <object class="GtkStackPage">
                 <property name="name">fail_page</property>
                 <property name="title" translatable="yes">Search Failure</property>
-                <property name="position">3</property>
-              </packing>
+                <property name="child">
+                  <object class="AdwStatusPage" id="search_fail_page">
+                    <property name="visible">True</property>
+                    <property name="icon-name">edit-find-symbolic</property>
+                    <property name="description" translatable="yes">No definition found</property>
+                  </object>
+                </property>
+              </object>
             </child>
             <child>
-              <object class="GtkSpinner">
-                <property name="visible">True</property>
-                <property name="active">True</property>
-              </object>
-              <packing>
+              <object class="GtkStackPage">
                 <property name="name">spinner_page</property>
                 <property name="title" translatable="yes">Loading</property>
-                <property name="position">4</property>
-              </packing>
+                <property name="child">
+                  <object class="GtkSpinner">
+                    <property name="spinning">True</property>
+                  </object>
+                </property>
+              </object>
             </child>
           </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
+    </child>
+    <child>
+      <object class="GtkEventControllerKey" id="key_ctrlr"/>
     </child>
   </template>
 </interface>

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,8 @@ else
 endif
 
 dependency('gobject-introspection-1.0', version: '>= 1.35.0')
-dependency('gtk+-3.0', version: '>= 3.22')
+dependency('gtk4', version: '>= 4.0.0')
+dependency('libadwaita-1', version: '>=1.0.0')
 dependency('glib-2.0')
 dependency('pygobject-3.0', version: '>= 3.29.1')
 

--- a/wordbook/main.py
+++ b/wordbook/main.py
@@ -4,9 +4,9 @@
 
 import gi
 
-gi.require_version("Gtk", "3.0")
-gi.require_version("Handy", "1")
-from gi.repository import Gio, GLib, Gtk, Handy  # noqa
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Gio, GLib, Gtk, Adw  # noqa
 
 from wordbook import base, utils  # noqa
 from wordbook.window import WordbookGtkWindow  # noqa
@@ -73,10 +73,10 @@ class Application(Gtk.Application):
             shortcuts_action.connect("activate", window.on_shortcuts)
             self.add_action(shortcuts_action)
 
-            self.add_accelerator("<Primary>s", "app.search-selected", None)
-            self.add_accelerator("<Primary>r", "app.random-word", None)
-            self.add_accelerator("<Primary><Shift>v", "app.paste-search", None)
-            self.add_accelerator("<Primary>comma", "app.preferences", None)
+            self.set_accels_for_action("app.search-selected", ["<Primary>s"])
+            self.set_accels_for_action("app.random-word", ["<Primary>r"])
+            self.set_accels_for_action("app.paste-search", ["<Primary><Shift>v"])
+            self.set_accels_for_action("app.preferences", ["<Primary>comma"])
 
         self.win = self.props.active_window
         if not self.win:
@@ -112,5 +112,5 @@ class Application(Gtk.Application):
         GLib.set_application_name("Wordbook")
         GLib.set_prgname(utils.APP_ID)
 
-        Handy.init()
+        Adw.init()
         base.fold_gen()

--- a/wordbook/settings_window.py
+++ b/wordbook/settings_window.py
@@ -82,7 +82,7 @@ class SettingsWindow(Adw.PreferencesWindow):
 
     def _on_live_search_activate(self, switch, _gparam):
         """Change live search state."""
-        self.parent.completer.set_popup_completion(not Settings.get().live_search)
+        # self.parent.completer.set_popup_completion(not Settings.get().live_search)
         Settings.get().live_search = switch.get_active()
 
     @staticmethod

--- a/wordbook/settings_window.py
+++ b/wordbook/settings_window.py
@@ -4,7 +4,7 @@
 
 import os
 
-from gi.repository import Gio, Gtk, Handy
+from gi.repository import Gio, Gtk, Adw
 
 from wordbook import utils
 from wordbook.settings import Settings
@@ -13,7 +13,7 @@ PATH = os.path.dirname(__file__)
 
 
 @Gtk.Template(resource_path=f"{utils.RES_PATH}/ui/settings_window.ui")
-class SettingsWindow(Handy.PreferencesWindow):
+class SettingsWindow(Adw.PreferencesWindow):
     """Allows the user to customize Wordbook to some extent."""
 
     __gtype_name__ = "SettingsWindow"
@@ -33,12 +33,12 @@ class SettingsWindow(Handy.PreferencesWindow):
         self.parent = parent
 
         # Pronunciations accent choices.
-        liststore = Gio.ListStore.new(Handy.ValueObject)
-        liststore.insert(0, Handy.ValueObject.new("American English"))
-        liststore.insert(1, Handy.ValueObject.new("British English"))
+        liststore = Gio.ListStore.new(Adw.ValueObject)
+        liststore.insert(0, Adw.ValueObject.new("American English"))
+        liststore.insert(1, Adw.ValueObject.new("British English"))
 
-        self._pronunciations_accent_row.bind_name_model(
-            liststore, Handy.ValueObject.dup_string
+        self._pronunciations_accent_row.set_model(
+            liststore
         )
 
         self.load_settings()
@@ -63,7 +63,7 @@ class SettingsWindow(Handy.PreferencesWindow):
         self._cdef_switch.set_active(Settings.get().cdef)
         self._double_click_switch.set_active(Settings.get().double_click)
         self._live_search_switch.set_active(Settings.get().live_search)
-        self._pronunciations_accent_row.set_selected_index(
+        self._pronunciations_accent_row.set_selected(
             Settings.get().pronunciations_accent_value
         )
 
@@ -88,7 +88,7 @@ class SettingsWindow(Handy.PreferencesWindow):
     @staticmethod
     def _on_pronunciations_accent_activate(row, _gparam):
         """Change pronunciations' accent."""
-        Settings.get().pronunciations_accent_value = row.get_selected_index()
+        Settings.get().pronunciations_accent_value = row.get_selected()
 
     @staticmethod
     def _on_dark_ui_switch_activate(switch, _gparam):

--- a/wordbook/window.py
+++ b/wordbook/window.py
@@ -7,7 +7,7 @@ import random
 import threading
 from html import escape, unescape
 
-from gi.repository import Gdk, Gio, GLib, Gtk, Handy
+from gi.repository import Gdk, Gio, GLib, GObject, Gtk, Adw
 from wn.util import ProgressHandler
 
 from wordbook import base, utils
@@ -16,7 +16,7 @@ from wordbook.settings import Settings
 
 
 @Gtk.Template(resource_path=f"{utils.RES_PATH}/ui/window.ui")
-class WordbookGtkWindow(Handy.ApplicationWindow):
+class WordbookGtkWindow(Adw.ApplicationWindow):
     __gtype_name__ = "WordbookGtkWindow"
 
     _header_bar = Gtk.Template.Child("header_bar")
@@ -28,8 +28,10 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
     loading_label = Gtk.Template.Child("loading_label")
     loading_progress = Gtk.Template.Child("loading_progress")
     _def_view = Gtk.Template.Child("def_view")
+    _def_ctrlr = Gtk.Template.Child("def_ctrlr")
     _pronunciation_view = Gtk.Template.Child("pronunciation_view")
     _term_view = Gtk.Template.Child("term_view")
+    _key_ctrlr = Gtk.Template.Child("key_ctrlr")
 
     _complete_list = []
     _completion_request_count = 0
@@ -56,16 +58,20 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
         menu = builder.get_object("wordbook-menu")
         self.set_icon_name(utils.APP_ID)
 
-        popover = Gtk.Popover.new_from_model(self._menu_button, model=menu)
+        popover = Gtk.PopoverMenu.new_from_model(menu)
         self._menu_button.set_popover(popover)
 
-        self.connect("key-press-event", self._on_key_press_event)
-        self._def_view.connect("button-press-event", self._on_def_event)
+        self._search_drop_target = Gtk.DropTarget.new(
+                GObject.GType.from_name("gchararray"), Gdk.DragAction.COPY)
+        self._search_entry.add_controller(self._search_drop_target)
+
+        self._key_ctrlr.connect("key-pressed", self._on_key_press_event)
+        self._def_ctrlr.connect("pressed", self._on_def_event)
         self._def_view.connect("activate-link", self._on_link_activated)
         self._search_button.connect("clicked", self.on_search_clicked)
         self._search_entry.connect("changed", self._on_entry_changed)
-        self._search_entry.connect("drag-data-received", self._on_drag_received)
-        self._search_entry.connect("paste-clipboard", self._on_paste_done)
+        self._search_drop_target.connect("accept", self._on_drag_received)
+        # self._search_entry.connect("paste-clipboard", self._on_paste_done)
         self._speak_button.connect("clicked", self._on_speak_clicked)
 
         # Loading and setup.
@@ -77,14 +83,14 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
 
         # Completions. This is kept separate because it uses its own weird logic.
         # This and related code might need refactoring later on.
-        self.completer = Gtk.EntryCompletion()
-        self.completer_liststore = Gtk.ListStore(str)
-        self.completer.set_text_column(0)
-        self.completer.set_model(self.completer_liststore)
-        self.completer.set_popup_completion(not Settings.get().live_search)
-        self.completer.get_popup_completion()
-        self._search_entry.set_completion(self.completer)
-        self.completer.connect("action-activated", self._on_entry_completed)
+        # self.completer = Gtk.EntryCompletion()
+        # self.completer_liststore = Gtk.ListStore(str)
+        # self.completer.set_text_column(0)
+        # self.completer.set_model(self.completer_liststore)
+        # self.completer.set_popup_completion(not Settings.get().live_search)
+        # self.completer.get_popup_completion()
+        # self._search_entry.set_completion(self.completer)
+        # self.completer.connect("action-activated", self._on_entry_completed)
 
     def on_about(self, _action, _param):
         """Show the about window."""
@@ -101,7 +107,6 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
         about_dialog.set_license_type(Gtk.License.GPL_3_0)
         about_dialog.set_website("https://www.github.com/fushinari/wordbook")
         about_dialog.set_copyright("Copyright © 2016-2021 Mufeed Ali")
-        about_dialog.connect("response", lambda dialog, response: dialog.destroy())
         about_dialog.present()
 
     def on_paste_search(self, _action, _param):
@@ -166,38 +171,40 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
 
     def _on_entry_changed(self, _entry):
         """Detect changes to text and do live search if enabled."""
-        self._completion_request_count += 1
-        if self._completion_request_count == 1:
-            threading.Thread(
-                target=self.__update_completions,
-                args=[self._search_entry.get_text()],
-                daemon=True,
-            ).start()
+
+        # self._completion_request_count += 1
+        # if self._completion_request_count == 1:
+        #     threading.Thread(
+        #         target=self.__update_completions,
+        #         args=[self._search_entry.get_text()],
+        #         daemon=True,
+        #     ).start()
+
         if self._pasted is True:
             self.__entry_cleaner()
             self._pasted = False
         if Settings.get().live_search:
             GLib.idle_add(self.on_search_clicked)
 
-    def _on_entry_completed(self, _entry_completion, index):
-        """Enter text into the entry using completions."""
-        text = (
-            self._complete_list[index]
-            .replace("<i>", "")
-            .replace("</i>", "")
-            .replace("<b>", "")
-            .replace("</b>", "")
-        )
-        self._search_entry.set_text(unescape(text))
-        self._search_entry.set_position(-1)
-        GLib.idle_add(self.on_search_clicked)
+    # def _on_entry_completed(self, _entry_completion, index):
+    #     """Enter text into the entry using completions."""
+    #     text = (
+    #         self._complete_list[index]
+    #         .replace("<i>", "")
+    #         .replace("</i>", "")
+    #         .replace("<b>", "")
+    #         .replace("</b>", "")
+    #     )
+    #     self._search_entry.set_text(unescape(text))
+    #     self._search_entry.set_position(-1)
+    #     GLib.idle_add(self.on_search_clicked)
 
-    def _on_key_press_event(self, _widget, event):
+    def _on_key_press_event(self, _a, keyval, keycode, state):
         """Focus onto the search entry when needed (quick search)."""
-        modifiers = event.get_state() & Gtk.accelerator_get_default_mod_mask()
+        modifiers = state & Gtk.accelerator_get_default_mod_mask()
 
         shift_mask = Gdk.ModifierType.SHIFT_MASK
-        key_unicode = Gdk.keyval_to_unicode(event.keyval)
+        key_unicode = Gdk.keyval_to_unicode(keyval)
         if GLib.unichar_isgraph(chr(key_unicode)) and modifiers in (shift_mask, 0):
             self._search_entry.grab_focus_without_selecting()
 
@@ -352,46 +359,46 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
         self.searched_term = None
         return None
 
-    def __update_completions(self, text):
-        while self._completion_request_count > 0:
-            while len(self._complete_list) > 0:
-                GLib.idle_add(self.completer.delete_action, 0)
-                self._complete_list.pop(0)
+    # def __update_completions(self, text):
+    #     while self._completion_request_count > 0:
+    #         while len(self._complete_list) > 0:
+    #             GLib.idle_add(self.completer.delete_action, 0)
+    #             self._complete_list.pop(0)
 
-            for item in self._search_history:
-                if len(self._complete_list) >= 10:
-                    break
-                if item and item.lower().startswith(text.lower()):
-                    item = f"<b>{escape(item)}</b>"
-                    if item in self._complete_list:
-                        self._complete_list.remove(item)
-                    self._complete_list.append(item)
+    #         for item in self._search_history:
+    #             if len(self._complete_list) >= 10:
+    #                 break
+    #             if item and item.lower().startswith(text.lower()):
+    #                 item = f"<b>{escape(item)}</b>"
+    #                 if item in self._complete_list:
+    #                     self._complete_list.remove(item)
+    #                 self._complete_list.append(item)
 
-            for item in self._wn_future.result()["list"]:
-                if len(self._complete_list) >= 10:
-                    break
-                item = item.replace("_", " ")
-                if item.lower().startswith(text.lower()):
-                    self._complete_list.append(item.replace("_", " "))
+    #         for item in self._wn_future.result()["list"]:
+    #             if len(self._complete_list) >= 10:
+    #                 break
+    #             item = item.replace("_", " ")
+    #             if item.lower().startswith(text.lower()):
+    #                 self._complete_list.append(item.replace("_", " "))
 
-            for item in os.listdir(utils.CDEF_DIR):
-                if len(self._complete_list) >= 10:
-                    break
-                item = escape(item).replace("_", " ")
-                if item in self._complete_list:
-                    self._complete_list.remove(item)
-                if item.lower().startswith(text.lower()):
-                    self._complete_list.append(f"<i>{item}</i>")
+    #         for item in os.listdir(utils.CDEF_DIR):
+    #             if len(self._complete_list) >= 10:
+    #                 break
+    #             item = escape(item).replace("_", " ")
+    #             if item in self._complete_list:
+    #                 self._complete_list.remove(item)
+    #             if item.lower().startswith(text.lower()):
+    #                 self._complete_list.append(f"<i>{item}</i>")
 
-            self._complete_list = sorted(self._complete_list)
-            for item in self._complete_list:
-                GLib.idle_add(
-                    self.completer.insert_action_markup,
-                    self._complete_list.index(item),
-                    item,
-                )
+    #         self._complete_list = sorted(self._complete_list)
+    #         for item in self._complete_list:
+    #             GLib.idle_add(
+    #                 self.completer.insert_action_markup,
+    #                 self._complete_list.index(item),
+    #                 item,
+    #             )
 
-            self._completion_request_count -= 1
+    #         self._completion_request_count -= 1
 
     def __wn_loader(self):
         self._header_bar.set_sensitive(False)

--- a/wordbook/window.py
+++ b/wordbook/window.py
@@ -80,6 +80,7 @@ class WordbookGtkWindow(Adw.ApplicationWindow):
             self._wn_future = base.get_wn_file(self.__reloader)
             self._header_bar.set_sensitive(True)
             self.__page_switch("welcome_page")
+            GLib.idle_add(self._search_entry.grab_focus_without_selecting)
 
         # Completions. This is kept separate because it uses its own weird logic.
         # This and related code might need refactoring later on.


### PR DESCRIPTION
Most things don't work or are untested.

[`gtk4-port`](https://github.com/fushinari/Wordbook/tree/gtk4-port) is another branch with an experimental port.

### Works:

- **About dialog**
- **Shortcuts dialog**
- **Live search**
- **Random search**
- **Basic searching**

### Almost Works:

- **Preferences dialog** - Pronunciations accent popover is broken and there are a lot of warnings.

### Not working:

- **Paste & Search** - needs to be ported to use GdkClipboard instead of GtkClipboard
- **Search Selected Text** - same as above
- **Completions** - `actions` seem to be gone from GTK4. I can't ~ab~use them anymore. So, rewriting this might be necessary.
- **Double click to search**
- **Enter to search**