### PR TITLE
window: Reset content scroll value when loading a page

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -262,7 +262,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkScrolledWindow">
+                          <object class="GtkScrolledWindow" id="content_scroll">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="hexpand">True</property>

--- a/wordbook/window.py
+++ b/wordbook/window.py
@@ -32,6 +32,7 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
     _stack = Gtk.Template.Child("main_stack")
     loading_label = Gtk.Template.Child("loading_label")
     loading_progress = Gtk.Template.Child("loading_progress")
+    _content_scroll = Gtk.Template.Child("content_scroll")
     _def_view = Gtk.Template.Child("def_view")
     _pronunciation_view = Gtk.Template.Child("pronunciation_view")
     _term_view = Gtk.Template.Child("term_view")
@@ -229,6 +230,7 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
 
         if status == "done":
             self.__page_switch("content_page")
+            self._content_scroll.get_vadjustment().set_value(0)
         elif status == "fail":
             self.__page_switch("fail_page")
         elif status == "welcome":

--- a/wordbook/window.py
+++ b/wordbook/window.py
@@ -230,7 +230,6 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
 
         if status == "done":
             self.__page_switch("content_page")
-            self._content_scroll.get_vadjustment().set_value(0)
         elif status == "fail":
             self.__page_switch("fail_page")
         elif status == "welcome":
@@ -364,6 +363,8 @@ class WordbookGtkWindow(Handy.ApplicationWindow):
         dialog.destroy()
 
     def __page_switch(self, page):
+        if page == "content_page":
+            GLib.idle_add(self._content_scroll.get_vadjustment().set_value, 0)
         if self._stack.get_visible_child_name == page:
             return True
         GLib.idle_add(self._stack.set_visible_child_name, page)


### PR DESCRIPTION
Just noticed this little nitpick, so decided to send a patch :P

I'm not used to the Wordbook code, so I don't know if the fix is in the right place.

**Before:**

https://user-images.githubusercontent.com/6210397/125729388-74ccb986-c90c-496d-8f92-fc6a05cb612c.mp4

**After:**

https://user-images.githubusercontent.com/6210397/125729603-4fa480e3-ef61-4816-9cb8-455db845ddb3.mp4
